### PR TITLE
Updated the logic of VariableByte Java version to match the C++ version

### DIFF
--- a/src/main/java/me/lemire/integercompression/VariableByte.java
+++ b/src/main/java/me/lemire/integercompression/VariableByte.java
@@ -7,7 +7,6 @@
 package me.lemire.integercompression;
 
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.nio.IntBuffer;
 
 /**
@@ -140,24 +139,24 @@ public class VariableByte implements IntegerCODEC, ByteIntegerCODEC {
 	public void uncompress(byte[] in, IntWrapper inpos, int inlength,
 			int[] out, IntWrapper outpos) {
 		int p = inpos.get();
-        int finalp = inpos.get() + inlength;
-        int tmpoutpos = outpos.get();
-        int v = 0;
-        int shift = 0;
-        for (; p < finalp; ++p) {
-                int c = in[p];
-                v += ((c & 127) << shift);
-                if ((c & 128) == 128) {
-                        out[tmpoutpos++] = v;
-                        v = 0;
-                        shift = 0;
-                } else
-                        shift += 7;
-        }
-        outpos.set(tmpoutpos);
-        inpos.add(p);
+		int finalp = inpos.get() + inlength;
+		int tmpoutpos = outpos.get();
+		int v = 0;
+		int shift = 0;
+		for (; p < finalp; ++p) {
+			int c = in[p];
+			v += ((c & 127) << shift);
+			if ((c & 128) == 128) {
+				out[tmpoutpos++] = v;
+				v = 0;
+				shift = 0;
+			} else
+				shift += 7;
+		}
+		outpos.set(tmpoutpos);
+		inpos.add(p);
 	}
-	
+
 	@Override
 	public String toString() {
 		return this.getClass().getSimpleName();


### PR DESCRIPTION
Hi Daniel,

I have updated the Java version of VariableByte to match the logic in the C++ version so that the versions are compatible in the compressed data that they produce. With this change it is now possible to compress in Java and decompress in C++ and vice versa to get back the original content. 

Thanks,
Samit
