### PR TITLE
Fix bug to make metadata compatible with C++ lib

### DIFF
--- a/src/main/java/me/lemire/integercompression/FastPFOR.java
+++ b/src/main/java/me/lemire/integercompression/FastPFOR.java
@@ -62,6 +62,7 @@ public final class FastPFOR implements IntegerCODEC {
                 // Initiate arrrays.
                 byteContainer = ByteBuffer.allocateDirect(3 * pageSize
                         / BLOCK_SIZE + pageSize);
+                byteContainer.order(ByteOrder.LITTLE_ENDIAN);
                 for (int k = 1; k < dataTobePacked.length; ++k)
                         dataTobePacked[k] = new int[pageSize / 32 * 4]; // heuristic
         }


### PR DESCRIPTION
Hi Daniel, 

I have corrected the metadata storage with little endianess so that the metadata gets read in correctly in the C++ layer (as explained in the mail) and vice versa.

Thanks,
Samit.
