### PR TITLE
Add Automatic-Module-Name in MANIFEST.MF

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,6 +234,13 @@
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>2.4</version>
+                    <configuration>
+                      <archive>
+                        <manifestEntries>
+                          <Automatic-Module-Name>me.lemire.integercompression</Automatic-Module-Name>
+                        </manifestEntries>
+                      </archive>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>


### PR DESCRIPTION
Current (0.3.10) MANIFEST.MF files looks like:
```
Manifest-Version: 1.0
Archiver-Version: Plexus Archiver
Created-By: Apache Maven 3.9.11
Built-By: runner
Build-Jdk: 21.0.9
```

Hence no `Automatic-Module-Name`.

It leads to difficulty for modularized projects themselves dependending on `JavaFastPFOR`.

e.g. from some LLM:
```
	// TODO: JavaFastPFOR (me.lemire.integercompression:JavaFastPFOR) has no Automatic-Module-Name,
	// so Maven keeps it on the classpath (unnamed module). Named modules cannot read unnamed modules
	// without a compiler flag. Two options to unblock:
	//   1. Ask upstream to add Automatic-Module-Name=me.lemire.integercompression to their MANIFEST.MF,
	//      then change this line to: requires me.lemire.integercompression;
	//   2. Add to maven-compiler-plugin compilerArgs in pom.xml:
	//        <compilerArg>--add-reads</compilerArg>
	//        <compilerArg>eu.solven.adhoc.encoding=ALL-UNNAMED</compilerArg>
	//      (option 2 does not need a requires directive here)
	// requires JavaFastPFOR;
```

https://stackoverflow.com/questions/46741907/what-is-an-automatic-module